### PR TITLE
Use awk env hasbang

### DIFF
--- a/shdoc
+++ b/shdoc
@@ -1,4 +1,4 @@
-#!/usr/bin/awk -f
+#!/usr/bin/env awk -f
 
 BEGIN {
     if (! style) {


### PR DESCRIPTION
awk is not always in /usr/bin/awk, and it's not possible to use alias or environment variables to override it.